### PR TITLE
Ignore abilities through config file 

### DIFF
--- a/config/lock.php
+++ b/config/lock.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'ignore_abilities' => [
+        'before'
+    ]
+];

--- a/src/Lock.php
+++ b/src/Lock.php
@@ -45,6 +45,7 @@ class Lock
         $reflection = new ReflectionClass($policy);
 
         return collect($reflection->getMethods(ReflectionMethod::IS_PUBLIC))
+            ->filter(fn (ReflectionMethod $method) => !in_array($method->getName(), config('lock.ignore_abilities', [])))
             ->map(fn (ReflectionMethod $method) => $method->getName())
             ->toArray();
     }

--- a/src/LockServiceProvider.php
+++ b/src/LockServiceProvider.php
@@ -8,8 +8,18 @@ use Illuminate\Support\ServiceProvider;
 
 class LockServiceProvider extends ServiceProvider
 {
+    public function register(): void
+    {
+        $this->mergeConfigFrom(
+            __DIR__ . '/../config/lock.php',
+            'lock'
+        );
+    }
+    
     public function boot(): void
     {
-        //
+        $this->publishes([
+            __DIR__ . '/../config/lock.php' => config_path('lock.php'),
+        ], 'lock-config');
     }
 }


### PR DESCRIPTION
When using
```
class PodcastData extends DataResource
{
  protected string $modelClass = Podcast::class;
}
```

It uses all public methods within the given `$modelClass`. 
Policies can be extended for example with a `before` method.

For example:

**PodcastPolicy:**
```
use \App\Models\User;
use \App\Models\Podcast;
use App\Traits\AlwaysAllowAdminPolicy;

class PodcastPolicy
{
    use AlwaysAllowAdminPolicy;
    ...
    public function view(User $user, Podcast $podcast): bool
    {
        return false;
    }
}
```

**AlwaysAllowAdminPolicy:**

```
use \App\Models\User;

trait AlwaysAllowAdminPolicy
{

    /**
     * Perform pre-authorization checks.
     */
    public function before(User $user, string $ability): bool
    {
        return $user->is_superadmin;
    }
}
```

In this case, the method view() will return true because the before is used.
Now the momentum/lock will also provide the permission "before".

This functionality allows you to ignore certain methods.
For example.

**config/lock.php:**
```
<?php

return [
    'ignore_abilities' => [
        'before'
    ]
];
```

It also can be published through `php artisan vendor:publish`
