### PR TITLE
Use Spatie's ClassTypeReflector in DataResourceCollector to allow for typescript type and DataResource to have different names

### DIFF
--- a/src/TypeScript/DataResourceCollector.php
+++ b/src/TypeScript/DataResourceCollector.php
@@ -8,6 +8,7 @@ use Momentum\Lock\Data\DataResource;
 use ReflectionClass;
 use Spatie\TypeScriptTransformer\Collectors\Collector;
 use Spatie\TypeScriptTransformer\Structures\TransformedType;
+use Spatie\TypeScriptTransformer\TypeReflectors\ClassTypeReflector;
 
 class DataResourceCollector extends Collector
 {
@@ -19,6 +20,7 @@ class DataResourceCollector extends Collector
 
         $transformer = new DataResourceTransformer($this->config);
 
-        return $transformer->transform($class, $class->getShortName());
+        $reflector = ClassTypeReflector::create($class);
+        return $transformer->transform($reflector->getReflectionClass(), $reflector->getName());
     }
 }


### PR DESCRIPTION
When using Spatie's TypeScript attribute with a DataResource, the naming did not change. 
I would include it in order to be able to have different names for the TypeScript type and the DataResource Class and to keep the expected behavior of the spatie/laravel-data package:

```php
#[TypeScript('Process')]
class ProcessData extends Momentum\Lock\Data\DataResource
{
   public function __construct(
      public string $uuid,
      public string $name,
   ) {}
}
```

would then be converted into (using the default TypeDefinitionWriter):

```TypeScript
export type App.Data.Process = {
uuid: string;
name: string;
}
```

Previous behavior for the PHP code at the top was like this:

```TypeScript
export type App.Data.ProcessData = {
uuid: string;
name: string;
}
```